### PR TITLE
Distinction between .pkb and .pks

### DIFF
--- a/icons/file-icons-icon-theme.json
+++ b/icons/file-icons-icon-theme.json
@@ -25965,7 +25965,7 @@
 		"pks": "_sql_medium-red",
 		"plb": "_sql_medium-red",
 		"plsql": "_sql_medium-red",
-		"pkb": "_sql_medium-red",
+		"pkb": "_sql_medium-blue",
 		"pod": "_pod_dark-blue",
 		"pogo": "_pogo_auto-orange",
 		"pony": "_pony_light-maroon",


### PR DESCRIPTION
.pkb (PacKageBody) and .pks (PacKageSpecification) normally come in pairs. If you have them in the same directory (which is common) a distinction with colors would be preferred.

E.g. this structure in a "PACKAGES" folder:
MY_COOL_PACKAGE.pks
MY_COOL_PACKAGE.pkb
NEW_PACKAGE.pks
NEW_PACKAGE.pkb
[...]


