### PR TITLE
Add support for webpack.analyze.js files

### DIFF
--- a/scripts/import-fixes.json
+++ b/scripts/import-fixes.json
@@ -143,6 +143,7 @@
 
 	"_webpack_medium-blue": [
 		"webpack.base.conf.js",
+		"webpack.analyze.js",
 		"webpack.common.js",
 		"webpack.config.js",
 		"webpack.config.base.js",


### PR DESCRIPTION
<!--
	NOTE:
	Please don't edit the icon-theme files directly; they're auto-generated.
	See CONTRIBUTING.md for details on how to add a new icon for a filetype.
-->
Add `webpack.analyze.js` support to `import-fixes.json`.
<img width="460" alt="Screen Shot 2020-12-15 at 6 35 39 pm" src="https://user-images.githubusercontent.com/58057927/102184917-572e4000-3f04-11eb-8788-d354e0c34af9.png">
