### PR TITLE
Add import fix for Stylelint and PostCSS variants

### DIFF
--- a/scripts/import-fixes.json
+++ b/scripts/import-fixes.json
@@ -67,6 +67,19 @@
 		"jestrc.json"
 	],
 
+	"_postcss_auto-yellow": [
+		"postcss.config.cjs",
+		"postcss.config.js",
+		"postcss.config.mjs"
+	],
+
+	"_stylelint_medium-purple": [
+		".stylelintrc.js",
+		".stylelintrc.json",
+		".stylelintrc.yaml",
+		".stylelintrc.yml"
+	],
+
 	"_test-js_auto-yellow": [
 		"_specs.js",
 		"_spec.js",


### PR DESCRIPTION
I've wanted to fix these for some time. The contribution guide provides! I've captured the indefinite vairants for [postcss](https://github.com/file-icons/atom/blob/master/config.cson#L5265) and [stylelint](https://github.com/file-icons/atom/blob/master/config.cson#L6389). Let me know if I'm missing anything!