### PR TITLE
Add support for `.gitkeep` files

### DIFF
--- a/scripts/import-fixes.json
+++ b/scripts/import-fixes.json
@@ -16,6 +16,7 @@
 
 	"_git_medium-red": [
 		"gitignore",
+		"gitkeep",
 		"gitmodules",
 		"gitattributes"
 	],


### PR DESCRIPTION
Uses the `import-fixes.json` file to give `.gitkeep` files the correct icon

Closes #78