### PR TITLE
Add missing filename entries for `tsconfig.FOO.json`

### DIFF
--- a/scripts/missing-filenames.txt
+++ b/scripts/missing-filenames.txt
@@ -46,6 +46,12 @@ postcss.config.mjs
 .stylelintrc.json
 .stylelintrc.yaml
 .stylelintrc.yml
+tsconfig.base.json
+tsconfig.es5.json
+tsconfig.eslint.json
+tsconfig.esm.json
+tsconfig.node.json
+tsconfig.spec.json
 webpack.analyze.js
 webpack.base.conf.cjs
 webpack.base.conf.coffee

--- a/scripts/missing-filenames.txt
+++ b/scripts/missing-filenames.txt
@@ -47,6 +47,7 @@ postcss.config.mjs
 .stylelintrc.yaml
 .stylelintrc.yml
 tsconfig.base.json
+tsconfig.build.json
 tsconfig.es5.json
 tsconfig.eslint.json
 tsconfig.esm.json


### PR DESCRIPTION
I'm perhaps showing a little bit of bias for my own projects :wink:
But these filenames are pretty popular.

- `tsconfig.base.json`: [+12k files](https://github.com/search?q=path%3A%2F%28%5E%7C%5C%2F%29tsconfig%5C.base%5C.json%24%2F&type=code)
- `tsconfig.build.json`: [+20k files](https://github.com/search?q=path%3A%2F%28%5E%7C%5C%2F%29tsconfig%5C.build%5C.json%24%2F&type=code)
- `tsconfig.es5.json`: [1k files](https://github.com/search?q=path%3A%2F%28%5E%7C%5C%2F%29tsconfig%5C.es5%5C.json%24%2F&type=code)
- `tsconfig.eslint.json`: [5k files](https://github.com/search?q=path%3A%2F%28%5E%7C%5C%2F%29tsconfig%5C.eslint%5C.json%24%2F&type=code)
- `tsconfig.esm.json`: [+1k (nearly 2k) files](https://github.com/search?q=path%3A%2F%28%5E%7C%5C%2F%29tsconfig%5C.esm%5C.json%24%2F&type=code)
- `tsconfig.node.json`: [+3k files](https://github.com/search?q=path%3A%2F%28%5E%7C%5C%2F%29tsconfig%5C.node%5C.json%24%2F&type=code)
- `tsconfig.spec.json`: [12k files](https://github.com/search?q=path%3A%2F%28%5E%7C%5C%2F%29tsconfig%5C.spec%5C.json%24%2F&type=code)

Resolves #91
