### PR TITLE
feat: Add support for `.pnpmfile.cjs` files

### DIFF
--- a/icons/file-icons-colourless-icon-theme.json
+++ b/icons/file-icons-colourless-icon-theme.json
@@ -9024,6 +9024,7 @@
 		"pkginfo": "_database",
 		"platformio.ini": "_platformio",
 		"pnpmfile.js": "_pnpm",
+		".pnpmfile.cjs": "_pnpm",
 		"pnpm-lock.yaml": "_pnpm",
 		"pnpm-lock.yml": "_pnpm",
 		"pnpm-workspace.yaml": "_pnpm",

--- a/icons/file-icons-icon-theme.json
+++ b/icons/file-icons-icon-theme.json
@@ -23537,6 +23537,7 @@
 			"owners": "_at_dark-red",
 			".photorec.cfg": "_photorec_dark-green",
 			"pnpmfile.js": "_pnpm_dark-yellow",
+			".pnpmfile.cjs": "_pnpm_dark-yellow",
 			"policyfile": "_chef_dark-orange",
 			"policyfile.lock": "_chef_dark-orange",
 			"postcss.config.cjs": "_postcss_dark-yellow",


### PR DESCRIPTION
The `.pnpmfile.cjs` file is the default `pnpm` script file, which allows us to hook directly into the installation process through special functions.